### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/6e6f386c74e04bb3bb48575ccce6b480)](https://www.codacy.com/app/eminetto/orcamentos)
 
-#Aplicativo de gerenciamento de Orçamentos
+# Aplicativo de gerenciamento de Orçamentos
 
 ### Configure o Apache VirtualHost
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
