### PR TITLE
Added missing requirement for date formatting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Silex sample",
     "require": {
         "php": ">=5.3.3",
+        "ext-intl": "*",
         "silex/silex": "1.0.*",
         "symfony/http-kernel": "*",
         "symfony/browser-kit": "*",


### PR DESCRIPTION
No readme é mencionada a necessidade do **intl** no entanto, por não estar no *composer.json* a instalação ocorre com sucesso mas causando erro no preview da proposta.